### PR TITLE
Updated extend() for null and typeof checks

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -87,11 +87,12 @@ function trim(text) {
  * keys.
  */
 function extend(base, obj) {
-  Object.keys(obj).forEach(function(key) {
-    if(!base.hasOwnProperty(key))
-      base[key] = obj[key];
-  });
-
+  if(base !== null && typeof base === "object" && obj !== null && typeof obj === "object"){
+    Object.keys(obj).forEach(function(key) {
+      if(!base.hasOwnProperty(key))
+        base[key] = obj[key];
+    });
+  }
   return base;
 }
 


### PR DESCRIPTION
The extend function was throwing an error (https://github.com/vpulim/node-soap/issues/585). This null and typeof check will handle elements that are not objects.